### PR TITLE
Add clickable links in explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is a graphical quiz application designed to help users study and practice f
 - 🗓️ Records score history with dates and displays it after each quiz.
 - 🌙 Optional dark mode via the `--dark` launch flag.
 - 🔁 Missed questions are stored and asked first on the next quiz.
+- 🔗 Clickable reference links in explanations.
 
 ## Prerequisites
 

--- a/quiz_app.py
+++ b/quiz_app.py
@@ -1,7 +1,9 @@
 import os
 import json
 import random
+import re
 import tkinter as tk
+import webbrowser
 from tkinter import messagebox
 from tkinter import font as tkfont
 
@@ -277,6 +279,19 @@ def show_result(parent, message):
 
     result_text = tk.Text(result_win, wrap="word", height=10, borderwidth=0, relief="flat", bg=result_win.cget("bg"))
     result_text.insert("1.0", message)
+
+    # Detect URLs and make them clickable
+    url_regex = re.compile(r"https?://\S+")
+    for match in url_regex.finditer(message):
+        start, end = match.span()
+        start_idx = f"1.0+{start}c"
+        end_idx = f"1.0+{end}c"
+        tag = f"link{start}"
+        url = match.group()
+        result_text.tag_add(tag, start_idx, end_idx)
+        result_text.tag_config(tag, foreground="blue", underline=1)
+        result_text.tag_bind(tag, "<Button-1>", lambda e, url=url: webbrowser.open_new(url))
+
     result_text.config(state="disabled", cursor="arrow")
     result_text.pack(padx=20, pady=10, fill="both", expand=True)
 


### PR DESCRIPTION
## Summary
- make reference links clickable by scanning the result text for URLs
- include `re` and `webbrowser` for hyperlink support
- highlight clickable references in the README

## Testing
- `python -m py_compile quiz_app.py main.py`
- `python main.py --help`

------
https://chatgpt.com/codex/tasks/task_e_686ecbd04760832eb08bd5f82f139f1a